### PR TITLE
shouldKamiFinalizeBlock

### DIFF
--- a/src/informer/to-esn/routine.ts
+++ b/src/informer/to-esn/routine.ts
@@ -58,5 +58,6 @@ export async function informerToESN(): Promise<void> {
     }
 
     console.log(`InformerToESN: Proposed ${blockNumber} block`);
+    const shouldKamiFinalizeBlock = await shouldPropose(blockNumber);
   }
 }

--- a/src/informer/to-esn/utils/finalize.ts
+++ b/src/informer/to-esn/utils/finalize.ts
@@ -29,6 +29,8 @@ export async function shouldPropose(blockNumber: number) {
           i
         );
         await global.nonceManagerESN.sendTransaction(populatedTx);
+        
+        console.log(`InformerToESN: Finalize ${blockNumber} block`);
       } catch {}
       return false;
     }


### PR DESCRIPTION
existing steps

STEP 1 get latest block number on ESN rplasma contract, get confirmed block number from ETH
STEP 2 find range of block numbers to make a proposal (confirmed to latestBlock)
STEP 3 before making a proposal, check if already made a proposal
STEP 5 check if it can be finalized (shouldPropose finalizes if consensus is acheived)  
else STEP 4 make the transaction if not already proposed

In new Kami

STEP 1 get latest block number on ESN rplasma contract, get confirmed block number from ETH
STEP 2 find range of block numbers to make a proposal (confirmed to latestBlock)
STEP 3 before making a proposal, check if already made a proposal
STEP 5 check if it can be finalized (shouldPropose finalizes if consensus is acheived)  
else STEP 4 make the transaction if not already proposed
then STEP 5 check if it can be finalized (shouldPropose finalizes if consensus is acheived) 
